### PR TITLE
Initialize basic Jira calendar app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # JiraApp
+
+This is a simple Node.js calendar application that can integrate with Jira. It uses Express for the server and FullCalendar for the front-end calendar view.
+
+## Setup
+
+1. Install dependencies:
+   ```sh
+   npm install
+   ```
+   *(You may need internet access for this step.)*
+
+2. Start the application:
+   ```sh
+   npm start
+   ```
+
+3. Visit `http://localhost:3000` in your browser to see the calendar.
+
+The `/api/events` endpoint currently returns sample data. Replace the logic in `index.js` with calls to the Jira REST API to load real issues and events.
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/api/events', (req, res) => {
+  // Placeholder: return sample data. Replace with Jira integration later.
+  res.json([
+    { id: 1, title: 'Sample Issue', start: '2025-07-01' },
+    { id: 2, title: 'Another Issue', start: '2025-07-05' }
+  ]);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "jiraapp",
+  "version": "1.0.0",
+  "description": "Simple Jira calendar app",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jira Calendar</title>
+  <link href='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css' rel='stylesheet' />
+  <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js'></script>
+  <style>
+    body { margin: 40px; font-family: Arial, sans-serif; }
+    #calendar { max-width: 900px; margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <h1>Jira Calendar</h1>
+  <div id='calendar'></div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var calendarEl = document.getElementById('calendar');
+      var calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'dayGridMonth',
+        events: '/api/events'
+      });
+      calendar.render();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize Node.js project
- add simple Express server with FullCalendar frontend
- document how to run the app

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68628a2b0c6c833092f80d45913e92a5